### PR TITLE
adding argument to not view app

### DIFF
--- a/R/shiny_dockerize.R
+++ b/R/shiny_dockerize.R
@@ -4,6 +4,7 @@
 #'   working directory)
 #' @param re.automagic logical; force automagic to recreate dependencies file
 #' @param app.name defaults to the basename of \code{directory}
+#' @param view_app defaults to TRUE, run the Docker container to preview
 #'
 #' @details This is a wrapper function that uses automagic package to build,
 #'   test, and view a dockerized shiny application. See
@@ -15,7 +16,7 @@
 #' @export
 #'
 shiny_dockerize <- function(directory=getwd(),re.automagic=FALSE,
-                            app.name=basename(directory)) {
+                            app.name=basename(directory), view_app=TRUE) {
   # if no dependencies file, make one (force rescan with re.automagic)
   if (!file.exists(file.path(directory,'deps.yaml')) | re.automagic) {
     if (re.automagic) unlink(file.path(directory,'deps.yaml'))
@@ -34,7 +35,8 @@ shiny_dockerize <- function(directory=getwd(),re.automagic=FALSE,
   build_docker_app(app.name)
 
   # test view it
-  message('running container to view the app...')
-  view_docker_app(app.name)
-
+  if (view_app) {
+    message('running container to view the app...')
+    view_docker_app(app.name)
+  }
 }


### PR DESCRIPTION
Here is a quick pull request to add an argument to make it possible to *not* view the app after building the container. Based on you having this set to view automatically, I infer that you would want the default to be to have view_app as TRUE. If it's normally the case that the user is running locally, this wouldn't hurt, although for a default it might be surprising.